### PR TITLE
Feature/logging

### DIFF
--- a/src/main/java/center/unit/beggar/BeggarApplication.java
+++ b/src/main/java/center/unit/beggar/BeggarApplication.java
@@ -2,8 +2,10 @@ package center.unit.beggar;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.web.servlet.ServletComponentScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@ServletComponentScan
 @EnableJpaAuditing
 @SpringBootApplication
 public class BeggarApplication {

--- a/src/main/java/center/unit/beggar/config/ApiLogFilter.java
+++ b/src/main/java/center/unit/beggar/config/ApiLogFilter.java
@@ -1,0 +1,56 @@
+package center.unit.beggar.config;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebFilter;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+import org.springframework.web.util.WebUtils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@WebFilter(urlPatterns = "/api/*")
+public class ApiLogFilter extends OncePerRequestFilter {
+
+	private final ObjectMapper objectMapper;
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+
+		log.info("[API URI] : {}", request.getRequestURI());
+
+		// ContentCachingXXXWrapper -> i/o Stream의 유실을 방지하기 위해 body를 caching하는 wrapper
+		ContentCachingRequestWrapper requestToCache = new ContentCachingRequestWrapper(request);
+		ContentCachingResponseWrapper responseToCache = new ContentCachingResponseWrapper(response);
+
+		filterChain.doFilter(requestToCache, responseToCache);
+
+		String beggarMemberId = requestToCache.getHeader("X-BEGGAR-MEMBER-ID");
+		if (beggarMemberId != null) {
+			log.info("X-BEGGAR-MEMBER-ID : {}", beggarMemberId);
+		}
+
+		log.info("Request Body : {}", objectMapper.readTree(requestToCache.getContentAsByteArray()));
+		log.info("Response Body : {}", objectMapper.readTree(responseToCache.getContentAsByteArray()));
+
+		responseToCache.copyBodyToResponse();
+	}
+
+}

--- a/src/main/java/center/unit/beggar/config/ApiLogFilter.java
+++ b/src/main/java/center/unit/beggar/config/ApiLogFilter.java
@@ -34,7 +34,7 @@ public class ApiLogFilter extends OncePerRequestFilter {
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
 		FilterChain filterChain) throws ServletException, IOException {
 
-		log.info("[API URI] : {}", request.getRequestURI());
+		log.info("[{}] : {}", request.getMethod(), request.getRequestURI());
 
 		// ContentCachingXXXWrapper -> i/o Stream의 유실을 방지하기 위해 body를 caching하는 wrapper
 		ContentCachingRequestWrapper requestToCache = new ContentCachingRequestWrapper(request);


### PR DESCRIPTION
 # API 요청에 대한 Log 남기기
Controller마다 수동 log 남기는 것 보다, Filter에서 일괄적(공통)으로 로그 남기기.
Interceptor보다 Filter에서 남기면 다음과 같은 이점이 있음

- 응답에 대한 로그를 남길 수 있다.
-  WAS(not spring) 영역의 책임인 Http에 대해 Filter에서 구현하는 것이 적절 => 내부 로직에서 오류가 발생해도 로그를 남길 수 있음

### 주의점
HttpServletRequest의 getReader() 메서드나 getInputStream()은 body의 값을 소비함
=> Spring에서 제공해주는 ContentCachingRequest(Response)Wrapper를 통해 값을 캐싱하여 로그를 남기도록 함

## 로그 형식
<img width="575" alt="Screen Shot 2022-09-26 at 16 58 05" src="https://user-images.githubusercontent.com/90550065/192223799-45eed626-0bbe-4296-ac7b-3a64799d0569.png">

[API 호출에 대해서만 로그를 남기도록 설정](https://github.com/unithon-9th-10th/backend/compare/feature/logging?expand=1#diff-fa10b5e78001fdd556962cf917b111eded437ff46380243999fd79faec5cb042R28)
